### PR TITLE
データベースのテーブルへのunique indexの追加

### DIFF
--- a/app/Models/Follow.php
+++ b/app/Models/Follow.php
@@ -9,7 +9,7 @@ class Follow extends Model
 {
     protected $fillable = [
         'user_id',
-        'followed_user_id',
+        'follower_id',
     ];
 
     public function user()

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -10,6 +10,7 @@ class image extends Model
     protected $fillable = [
         'tweet_id',
         'name',
+        'original_name',
         'type',
         'size',
     ];

--- a/app/Models/Tweet.php
+++ b/app/Models/Tweet.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Tweet extends Model
 {
     protected $table = 'tweets';
+
     protected $fillable = [
         'user_id',
         'body',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,32 +11,17 @@ class User extends Authenticatable
 {
     use HasFactory, Notifiable;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
     protected $fillable = [
         'name',
         'email',
         'password',
     ];
 
-    /**
-     * The attributes that should be hidden for arrays.
-     *
-     * @var array
-     */
     protected $hidden = [
         'password',
         'remember_token',
     ];
 
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];

--- a/database/migrations/2021_04_21_170308_update_tweet_likes_add_unique_combination_index_to_tweet_id_and_user_id.php
+++ b/database/migrations/2021_04_21_170308_update_tweet_likes_add_unique_combination_index_to_tweet_id_and_user_id.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateTweetLikesAddUniqueCombinationIndexToTweetIdAndUserId extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tweet_likes', function (Blueprint $table) {
+            $table->unique(['tweet_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tweet_likes', function (Blueprint $table) {
+            $table->dropUnique(['tweet_id', 'user_id']);
+        });
+    }
+}

--- a/database/migrations/2021_04_21_171237_update_follows_add_unique_combination_index_to_user_id_and_follower_id.php
+++ b/database/migrations/2021_04_21_171237_update_follows_add_unique_combination_index_to_user_id_and_follower_id.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateFollowsAddUniqueCombinationIndexToUserIdAndFollowerId extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('follows', function (Blueprint $table) {
+            $table->unique(['user_id', 'follower_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('follows', function (Blueprint $table) {
+            $table->dropUnique(['user_id', 'follower_id']);
+        });
+    }
+}


### PR DESCRIPTION
### (1) Followsモデル内変数の名前の変更
'followed_user_id' >> 'follower_id'
### (2) tweet_likesテーブルのteet_idとuser_idの組み合わせに対する、unique indexの追加
@ database/migrations/2021_04_21_170308_update_tweet_likes_add_unique_combination_index_to_tweet_id_and_user_id.php
### (3) followsテーブルのuser_idとfollower_idの組み合わせに対する、unique indexの追加
@ database/migrations/2021_04_21_171237_update_follows_add_unique_combination_index_to_user_id_and_follower_id.php